### PR TITLE
Update Navbar links and rename project in package-lock

### DIFF
--- a/app/components/navbar.jsx
+++ b/app/components/navbar.jsx
@@ -26,13 +26,10 @@ function Navbar() {
             <Link className="block px-4 py-2 no-underline outline-none hover:no-underline" href="/#skills"><div className="text-sm text-white transition-colors duration-300 hover:text-pink-600">SKILLS</div></Link>
           </li>
           <li>
-            <Link className="block px-4 py-2 no-underline outline-none hover:no-underline" href="/#education"><div className="text-sm text-white transition-colors duration-300 hover:text-pink-600">EDUCATION</div></Link>
-          </li>
-          <li>
-            <Link className="block px-4 py-2 no-underline outline-none hover:no-underline" href="/blog"><div className="text-sm text-white transition-colors duration-300 hover:text-pink-600">BLOGS</div></Link>
-          </li>
-          <li>
             <Link className="block px-4 py-2 no-underline outline-none hover:no-underline" href="/#projects"><div className="text-sm text-white transition-colors duration-300 hover:text-pink-600">PROJECTS</div></Link>
+          </li>
+          <li>
+            <Link className="block px-4 py-2 no-underline outline-none hover:no-underline" href="/#education"><div className="text-sm text-white transition-colors duration-300 hover:text-pink-600">EDUCATION</div></Link>
           </li>
         </ul>
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "developer-portfolio",
+  "name": "portfolio",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "developer-portfolio",
+      "name": "portfolio",
       "version": "0.1.0",
       "dependencies": {
         "@emailjs/browser": "^4.3.1",


### PR DESCRIPTION
6bc58a009e2b6bdc6825d88d8a0a827505141261

- Reordered "EDUCATION" and "PROJECTS" links in Navbar.
- Removed "BLOGS" link from Navbar.
- Changed project name in package-lock.json from "developer-portfolio" to "portfolio".